### PR TITLE
Handle namespace clear in app deploy modal differently

### DIFF
--- a/src/deploy/AppDeployModal.js
+++ b/src/deploy/AppDeployModal.js
@@ -90,7 +90,6 @@ export default function AppDeployModal({
       timeoutActive.current = false;
       setWsResponses((state) => [...state, response]);
       setCanCloseModal(true);
-      dispatch(clearNamespaces());
       socket.current.disconnect();
     });
 
@@ -119,6 +118,7 @@ export default function AppDeployModal({
   const close = () => {
     setShowModal(false);
     timeoutActive.current = false; // Ensure the timeout is disabled when the modal is closed
+    dispatch(clearNamespaces());
   };
 
   const getButtonLabel = () => {

--- a/src/deploy/AppDeployOptionsCard.js
+++ b/src/deploy/AppDeployOptionsCard.js
@@ -19,7 +19,6 @@ import {
   setPool,
   setDuration,
   setTargetEnv,
-  setFallbackRefEnv,
   getAppDeployTargetEnv,
   getAppDeployRefEnv,
   setRefEnv,
@@ -69,9 +68,6 @@ export default function AppDeployoptionsCard() {
     dispatch(setRefEnv(value));
   };
   const fallbackRefEnv = useSelector(getAppDeployRefEnv);
-  const setStoreFallbackRefEnv = (value) => {
-    dispatch(setFallbackRefEnv(value));
-  };
   const getDependencies = useSelector(getAppDeployGetDependencies);
   const setStoreGetDependencies = (value) => {
     dispatch(setGetDependencies(value));


### PR DESCRIPTION
The namespace list clear on EndEvent caused the modal to close before the user could read the message.