### PR TITLE
fix(reserve): wire duration and pool selects with value/setValue

### DIFF
--- a/src/namespaces/NamespaceReserve.js
+++ b/src/namespaces/NamespaceReserve.js
@@ -97,8 +97,8 @@ export default function NamespaceReserve() {
           isDisabled
         />
       </FormGroup>
-      <DurationSelectList duration={duration} setDuration={setDuration} />
-      <PoolSelectList pool={pool} setPool={setPool} />
+      <DurationSelectList value={duration} setValue={setDuration} />
+      <PoolSelectList value={pool} setValue={setPool} />
       <FormGroup
         label="Allow Multiple Reservations"
         fieldId="simple-form-force-01"


### PR DESCRIPTION
## Summary

Fixes the Reserve Namespace page so the Duration and Pool dropdowns update when an option is chosen. The selects were given the wrong prop names, so their internal `onSelect` handler never called a real setter.

## Problem

`DurationSelectList` and `PoolSelectList` (in `CustomSelects.js`) expect `value` and `setValue`, matching the shared `SelectListComponent` API. `NamespaceReserve.js` passed `duration` / `setDuration` and `pool` / `setPool`, which those components do not use. As a result, `setValue` was `undefined`, selections did not persist, and the UI looked broken.

## Solution

Pass `value={duration}` / `setValue={setDuration}` and `value={pool}` / `setValue={setPool}` from `NamespaceReserve.js`, consistent with `AppDeployOptionsCard.js`.

## How to test

1. Open `/namespace/reserve`.
2. Open the Duration dropdown and choose `1h`, `4h`, or `8h`; confirm the toggle label updates and the choice sticks.
3. Open the Pool dropdown and choose another pool; confirm the label updates and the choice sticks.
4. Submit a reservation (if applicable in your env) and confirm the request uses the selected duration and pool.

## Notes

No changes to `CustomSelects.js`; the bug was limited to the reserve page call site.