### PR TITLE
Add renovate config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,55 +1,55 @@
 {
-  "name": "firelink-ui",
-  "version": "0.1.0.1",
-  "private": true,
-  "dependencies": {
-    "@patternfly/react-core": "^6.3.1",
-    "@patternfly/react-styles": "^6.3.1",
-    "@patternfly/react-table": "^6.3.1",
-    "@reduxjs/toolkit": "^2.1.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/user-event": "^14.0.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "react-linkify": "^1.0.0-alpha",
-    "react-redux": "^9.1.0",
-    "react-router-dom": "^7.0.0",
-    "react-scripts": "^5.0.1",
-    "react-spring": "^10.0.0",
-    "react-svg": "^16.1.33",
-    "redux-persist": "^6.0.0",
-    "socket.io-client": "^4.7.4",
-    "web-vitals": "^5.0.0"
-  },
-  "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "engines": {
-    "node": ">=22.0.0"
-  },
-  "devDependencies": {
-    "@testing-library/react": "^16.0.0",
-    "http-proxy-middleware": "^3.0.0"
-  }
+	"name": "firelink-ui",
+	"version": "0.1.0.1",
+	"private": true,
+	"dependencies": {
+		"@patternfly/react-core": "^6.3.1",
+		"@patternfly/react-styles": "^6.3.1",
+		"@patternfly/react-table": "^6.3.1",
+		"@reduxjs/toolkit": "^2.1.0",
+		"@testing-library/jest-dom": "^6.0.0",
+		"@testing-library/user-event": "^14.0.0",
+		"react": "^19.0.0",
+		"react-dom": "^19.0.0",
+		"react-linkify": "^1.0.0-alpha",
+		"react-redux": "^9.1.0",
+		"react-router-dom": "^7.0.0",
+		"react-scripts": "^5.0.1",
+		"react-spring": "^10.0.0",
+		"react-svg": "^16.1.33",
+		"redux-persist": "^6.0.0",
+		"socket.io-client": "^4.7.4",
+		"web-vitals": "^5.0.0"
+	},
+	"scripts": {
+		"start": "react-scripts start",
+		"build": "react-scripts build",
+		"test": "react-scripts test",
+		"eject": "react-scripts eject"
+	},
+	"eslintConfig": {
+		"extends": [
+			"react-app",
+			"react-app/jest"
+		]
+	},
+	"browserslist": {
+		"production": [
+			">0.2%",
+			"not dead",
+			"not op_mini all"
+		],
+		"development": [
+			"last 1 chrome version",
+			"last 1 firefox version",
+			"last 1 safari version"
+		]
+	},
+	"engines": {
+		"node": ">=22.0.0"
+	},
+	"devDependencies": {
+		"@testing-library/react": "^16.0.0",
+		"http-proxy-middleware": "^3.0.0"
+	}
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,29 @@
+{
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": [
+		":disableMajorUpdates",
+		"github>konflux-ci/mintmaker-presets:cve-automerge-all",
+		":npm",
+		":group:react"
+	],
+	"dockerfile": {
+		"managerFilePatterns": [
+			"/Dockerfile$/"
+		]
+	},
+	"packageRules": [
+		{
+			"matchDatasources": [ "docker" ],
+			"matchPackageNames": [
+				"registry.access.redhat.com/ubi9/nodejs-22"
+			],
+			"versioning": "redhat"
+		},
+		{
+			"groupName": "patternfly packages",
+			"matchPackageNames": [
+				"@patternfly/**"
+			]
+		}
+	]
+}


### PR DESCRIPTION
Add mintmaker config file to set custom rules:

- enabling grouping for patternfly and react packages
- set automerge config for CVEs
- disable major updates for packages
- set tag rules for redhat images

When we merge this we can turn on the mintmaker-automerge custom property in the repo to allow Konflux to merge without approvals